### PR TITLE
fix crash that occurs when file is not saved yet

### DIFF
--- a/anim_to_minecraft.lua
+++ b/anim_to_minecraft.lua
@@ -49,8 +49,15 @@ if app.activeSprite ~= nil then
         end
 
         filename = spr.filename:match("^(.+)%..+$")
-        newSpr:saveAs(filename..".png")
-        newSpr:close()
+        if filename ~= nil then
+            newSpr:saveAs(filename..".png")
+            newSpr:close()
+        else
+            local err_dlg = Dialog{title = "Error exporting mc animation"}
+            err_dlg:label { id="errLabel", text="Failed to export mc animation to file because it has not been saved yet" }
+            err_dlg:show()
+            return
+        end
 
         framespeed = tonumber(data.fpsEntry)
 

--- a/anim_to_minecraft.lua
+++ b/anim_to_minecraft.lua
@@ -23,6 +23,15 @@ if app.activeSprite ~= nil then
         local width = spr.width
         local height = spr.height
 
+        filename = spr.filename:match("^(.+)%..+$")
+
+        if filename == nil then
+            local err_dlg = Dialog { title = "Error exporting mc animation" }
+            err_dlg:label { id = "errLabel", text = "Failed to export mc animation to file because it has not been saved yet" }
+            err_dlg:show()
+            return
+        end
+
         -- Create a new sprite with the desired width and height
         local newSpr = Sprite(width, height * #spr.frames, spr.colorMode, spr.pixelRatio)
         local newLayer = newSpr.layers[1]
@@ -48,16 +57,8 @@ if app.activeSprite ~= nil then
             end
         end
 
-        filename = spr.filename:match("^(.+)%..+$")
-        if filename ~= nil then
-            newSpr:saveAs(filename..".png")
-            newSpr:close()
-        else
-            local err_dlg = Dialog{title = "Error exporting mc animation"}
-            err_dlg:label { id="errLabel", text="Failed to export mc animation to file because it has not been saved yet" }
-            err_dlg:show()
-            return
-        end
+        newSpr:saveAs(filename..".png")
+        newSpr:close()
 
         framespeed = tonumber(data.fpsEntry)
 


### PR DESCRIPTION
This creates an error dialog that appears if a animation file has not been saved yet and therefore the filename is nil. Although it does not directly fix the crash, it gives the user a bit more information about the issue.